### PR TITLE
プロフィール表示・編集機能修正版

### DIFF
--- a/ChatApp/app.py
+++ b/ChatApp/app.py
@@ -319,8 +319,6 @@ def edit_profile_view():
     return render_template('edit_profile.html', user_id=user_id)
 
 
-
-
 if __name__ == '__main__':
     print("Starting Flask application...")
     app.run(host='0.0.0.0', debug=True)

--- a/ChatApp/models.py
+++ b/ChatApp/models.py
@@ -47,8 +47,17 @@ class User:
           finally:
               db_use.release(conn)
 
-
+      
      @classmethod
+     def update_profile(cls, user_id, nickname, icon_image_url, favorite, bio):
+         conn = db_use.get_conn()
+         try:
+            with conn.cursor() as cursor:
+                sql = "UPDATE users SET nickname = %s, icon_image_url = %s, favorite = %s, bio = %s WHERE user_id = %s"
+                cursor.execute(sql, (nickname, icon_image_url, favorite, bio, user_id))
+                conn.commit()
+         finally:
+             db_use.release(conn)@classmethod
      def update_profile(cls, user_id, nickname, icon_image_url, favorite, bio):
          conn = db_use.get_conn()
          try:

--- a/ChatApp/models.py
+++ b/ChatApp/models.py
@@ -17,8 +17,8 @@ class User:
           conn = db_use.get_conn()
           try:
             with conn.cursor() as cursor:
-                sql = "INSERT INTO users (user_id, email, password, nickname) VALUES (%s, %s, %s, %s)"
-                cursor.execute(sql, (user_id, email, password, nickname))
+                sql = "INSERT INTO users (user_id, email, password, nickname, icon_image_url, favorite, bio) VALUES (%s, %s, %s, %s, %s, %s, %s)"
+                cursor.execute(sql, (user_id, email, password, nickname, '/static/image/icon', '未登録', ''))
                 conn.commit()
           finally:
               db_use.release(conn)
@@ -47,17 +47,37 @@ class User:
           finally:
               db_use.release(conn)
 
-      
+     
      @classmethod
-     def update_profile(cls, user_id, nickname, icon_image_url, favorite, bio):
+     def get_user_by_id(cls, user_id):
          conn = db_use.get_conn()
          try:
-            with conn.cursor() as cursor:
-                sql = "UPDATE users SET nickname = %s, icon_image_url = %s, favorite = %s, bio = %s WHERE user_id = %s"
-                cursor.execute(sql, (nickname, icon_image_url, favorite, bio, user_id))
-                conn.commit()
+             with conn.cursor() as cursor:
+                 sql = "SELECT nickname, icon_image_url, favorite, bio FROM users WHERE user_id = %s"
+                 cursor.execute(sql, (user_id,))
+                 result = cursor.fetchone()
+                 if result is not None:
+                     if isinstance(result, dict):
+                         return{
+                             'nickname': result.get('nickname', ''),
+                             'icon_image_url': result.get('icon_image_url', ''),
+                             'favorite': result.get('favorite', ''),
+                             'bio': result.get('bio', '')
+                             }
+                     else:
+                         return {
+                             'nickname': result[0],
+                             'icon_image_url': result[1],
+                             'favorite': result[2],
+                             'bio': result[3]
+                         }
+                 return None
          finally:
-             db_use.release(conn)@classmethod
+             db_use.release(conn)
+ 
+
+
+     @classmethod
      def update_profile(cls, user_id, nickname, icon_image_url, favorite, bio):
          conn = db_use.get_conn()
          try:

--- a/ChatApp/templates/index.html
+++ b/ChatApp/templates/index.html
@@ -14,7 +14,7 @@
         <h4>メニュー</h4>
         <a class="menu-button" href="{{ url_for('room_create_view') }}"><i class="fas fa-plus"></i> ルーム作成</a>
         <a class="menu-button" href="{{ url_for('room_search_view') }}"><i class="fas fa-search"></i> ジャンル検索</a>
-        <a class="menu-button" href="{{ url_for('profile_view') }}"><i class="fas fa-user"></i> プロフィール</a>
+        <a class="menu-button" href="{{ url_for('profile_view', user_id=current_user.user_id) }}"><i class="fas fa-user"></i> プロフィール</a>
     </div>
     <div class="menu-footer">
         <a class="logout-button" href="{{ url_for('logout') }}"><i class="fas fa-sign-out-alt"></i> ログアウト</a>


### PR DESCRIPTION
・`/profile/<user_id>` および `/edit_profile/<user_id>` のようにルーティングに user_id を付与
・プロフィール表示・編集時に渡すデータを user_id のみから nickname, icon_image_url, favorite, bio に変更
・Flask-Loginに対応するため、session ではなく current_user に変更

